### PR TITLE
:bug: Fixes thrown TypeError when body is passed in GET request

### DIFF
--- a/src/v1/generateIdxAction.js
+++ b/src/v1/generateIdxAction.js
@@ -19,6 +19,10 @@ import makeIdxState from './makeIdxState';
 const generateDirectFetch = function generateDirectFetch( { actionDefinition, defaultParamsForAction = {}, immutableParamsForAction = {}, toPersist } ) {
   const target = actionDefinition.href;
   return async function(params) {
+    // For GET and HEAD requests - do not include body
+    const reqBody = ['GET', 'HEAD'].includes(actionDefinition.method)
+      ? undefined
+      : JSON.stringify({ ...defaultParamsForAction, ...params, ...immutableParamsForAction });
     return fetch(target, {
       method: actionDefinition.method,
       headers: {
@@ -26,7 +30,7 @@ const generateDirectFetch = function generateDirectFetch( { actionDefinition, de
         'content-type': 'application/json',
         'accept': actionDefinition.accepts || 'application/ion+json',
       },
-      body: JSON.stringify({ ...defaultParamsForAction, ...params, ...immutableParamsForAction })
+      body: reqBody
     })
       .then( response => {
         const respJson = response.json();


### PR DESCRIPTION
### Description

When a `GET` or `HEAD` request includes a request body, the underlying [cross-fetch](https://github.com/lquixada/cross-fetch/blob/baded8cca7aa00b1aa91f6cf57bc7ed0e3c57aa6/dist/browser-ponyfill.js#L355-L357) library throws a `TypeError`. This code change includes the `body` for non-`GET` and `HEAD` requests.

Another reference:
- https://github.com/github/fetch/issues/402
