### PR TITLE
feat: support loading from saved interactionHandle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.9.0
+
+### Features
+
+- [#47](https://github.com/okta/okta-idx-js/pull/47) Supports passing an `interactionHandle` to `start()`
+
 # 0.8.2
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-idx-js",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Okta JS-based consumption layer for IDX API",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const start = async function start({
   domain,
   issuer,
   stateHandle,
+  interactionHandle,
   version,
   redirectUri,
   state,
@@ -29,8 +30,6 @@ const start = async function start({
   codeChallenge,
   codeChallengeMethod,
 }) {
-
-  let interactionHandle;
 
   issuer = issuer?.replace(/\/+$/, '');
   const baseUrl = issuer?.indexOf('/oauth2') > 0 ? issuer : issuer + '/oauth2'; // org AS uses domain as AS, but we need the base url for calls
@@ -69,7 +68,7 @@ const start = async function start({
     return Promise.reject({ error: 'invalid version supplied - version is required and uses semver syntax'});
   }
 
-  if ( !stateHandle ) { // customer-hosted
+  if ( !stateHandle && !interactionHandle ) { // start a new transaction
     try {
       const bootstrapParams = {
         clientId,


### PR DESCRIPTION
Will call `introspect` if either a stateHandle or interactionHandle were passed.

Needed to support: https://github.com/okta/okta-signin-widget/pull/1653