### PR TITLE
feat: Returns idxState on introspect errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.11.0
+
+### Features
+
+- [#49](https://github.com/okta/okta-idx-js/pull/49) Transforms `introspect` errors into a recoverable `idxState`
+
 # 0.10.0
 
 ### Other

--- a/scripts/license-template.txt
+++ b/scripts/license-template.txt
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/scripts/maintain-banners.js
+++ b/scripts/maintain-banners.js
@@ -13,7 +13,7 @@ const firstYear = match[2];
 const currentYear = new Date().getFullYear().toString();
 
 if (firstYear !== currentYear) {
-  fs.writeFileSync(bannerSourcePath, bannerSource.replace(copyrightRegex, `$1$2-${currentYear}`));
+  fs.writeFileSync(bannerSourcePath, bannerSource.replace(copyrightRegex, `$1${currentYear}-`));
 }
 
 files.forEach(file => {
@@ -24,6 +24,6 @@ files.forEach(file => {
   }
   const firstYear = match[2];
   if (firstYear !== currentYear) {
-    return fs.writeFileSync(file, contents.replace(copyrightRegex, `$1$2-${currentYear}`));
+    return fs.writeFileSync(file, contents.replace(copyrightRegex, `$1${currentYear}-`));
   }
 });

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
@@ -91,7 +91,12 @@ const start = async function start({
   try {
     const { makeIdxState } = parsersForVersion(version);
     const idxResponse = await introspect({ domain, interactionHandle, stateHandle, version })
-      .catch( err => Promise.reject({ error: 'introspect call failed', details: err }) );
+      .catch( err => Promise.reject({
+        error: 'introspect call failed',
+        // Transform all errors into an IdX State object.
+        // This allows IdX based errors (messages) to optionally proceed with remediation forms
+        details: makeIdxState( err, toPersist )
+      }) );
     const idxState = makeIdxState( idxResponse, toPersist );
     return idxState;
   } catch (error) {

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/userAgent.js
+++ b/src/userAgent.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/v1/actionParser.js
+++ b/src/v1/actionParser.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/v1/generateIdxAction.js
+++ b/src/v1/generateIdxAction.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/v1/idxResponseParser.js
+++ b/src/v1/idxResponseParser.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/v1/makeIdxState.js
+++ b/src/v1/makeIdxState.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/v1/parsers.js
+++ b/src/v1/parsers.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/v1/remediationParser.js
+++ b/src/v1/remediationParser.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
  * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
  *
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.

--- a/test/mocks/error-authenticator-enroll.json
+++ b/test/mocks/error-authenticator-enroll.json
@@ -1,0 +1,105 @@
+{
+  "stateHandle": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-19T15:10:35.000Z",
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Unable to enroll. Try again or contact your admin for assistance.",
+        "i18n": {
+          "key": "",
+          "params": []
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "name": "redirect-idp",
+        "type": "OIDC",
+        "idp": {
+          "id": "0oa69chx4bZyx8O7l0g4",
+          "name": "IDP Authenticator"
+        },
+        "href": "http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "method": "GET",
+        "relatesTo" : [ "$.currentAuthenticator" ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "key": "external_idp",
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": []
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": { "id": "00u2m55pu8UZyeMMl0g4" }
+  },
+  "cancel": {
+    "rel": [ "create-form" ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Test OIDC App",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}


### PR DESCRIPTION
### Description

For cases where `introspect` returns an error, transform the error message it into an `idxState`. This allows handlers of the resolved error to recover in IDX flows.
