### PR TITLE
feat: Adds ability to pass in request interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.14.0
+
+### Features
+
+- [#54](https://github.com/okta/okta-idx-js/pull/54) Adds the ability to pass in HTTP request interceptors
+
 # 0.13.0
 
 ### Fixes

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -11,10 +11,9 @@
  */
 
 
-import fetch from 'cross-fetch';
-import { userAgentHeaders } from './userAgent';
+import { request } from './client';
 
-const parseAndReject = response =>  response.json().then( err => Promise.reject(err));
+const parseAndReject = response => response.json().then( err => Promise.reject(err) );
 
 const bootstrap = async function bootstrap({
   clientId,
@@ -23,7 +22,7 @@ const bootstrap = async function bootstrap({
   redirectUri,
   codeChallenge,
   codeChallengeMethod,
-  state
+  state,
 }) {
 
   const target = `${baseUrl}/v1/interact`;
@@ -37,16 +36,12 @@ const bootstrap = async function bootstrap({
   })
     .map( ([param, value]) => `${param}=${encodeURIComponent(value)}` )
     .join('&');
+  const headers = {
+    'content-type': 'application/x-www-form-urlencoded',
+  };
 
-  return fetch(target, {
-    method: 'POST',
-    headers: {
-      ...userAgentHeaders(),
-      'content-type': 'application/x-www-form-urlencoded',
-    },
-    body,
-  })
-    .then( response => response.ok ? response.json() : parseAndReject(response) )
+  return request(target, { headers, body })
+    .then( response => response.ok ? response.json() : parseAndReject( response ) )
     .then( data => data.interaction_handle);
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -1,0 +1,75 @@
+/*!
+ * Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+import fetch from 'cross-fetch';
+import { userAgentHeaders } from './userAgent';
+
+/**
+ * Reusable interceptor interface
+ */
+function Interceptor() {
+  this.handlers = [];
+
+  // Adds a new interceptor to our HttpClient
+  this.use = function(before) {
+    this.handlers.push({
+      before,
+    });
+  };
+
+  // Clears all interceptors
+  this.clear = function() {
+    this.handlers = [];
+  };
+}
+
+/**
+ * Singleton instance of the IdX HTTP Client
+ *
+ * Invoke the `use` method to add a new interceptor:
+ *   - client.interceptors.request.use((requestConfig) => { some logic });
+ */
+const HttpClient = {
+  interceptors: {
+    request: new Interceptor(),
+  },
+};
+
+const request = async function request( target, { method = 'POST', headers = {}, body } ) {
+  const requestOptions = {
+    url: target,
+    method,
+    headers: {
+      ...userAgentHeaders(),
+      ...headers,
+    },
+    body,
+  };
+
+  if (HttpClient.interceptors) {
+    HttpClient.interceptors.request.handlers.forEach( interceptor => {
+      interceptor.before(requestOptions);
+    });
+  }
+
+  // Extract the URL to adhere to the fetch API
+  const { url } = requestOptions;
+  delete requestOptions.url;
+
+  return fetch( url, requestOptions );
+};
+
+export {
+  HttpClient,
+  request,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@
 import introspect from './introspect';
 import bootstrap from './bootstrap';
 import parsersForVersion from './parsers';
+import { HttpClient } from './client';
 
 const LATEST_SUPPORTED_IDX_API_VERSION = '1.0.0';
 
@@ -106,5 +107,6 @@ const start = async function start({
 
 export default {
   start,
+  client: HttpClient,
   LATEST_SUPPORTED_IDX_API_VERSION,
 };

--- a/src/introspect.js
+++ b/src/introspect.js
@@ -11,23 +11,20 @@
  */
 
 
-import fetch from 'cross-fetch';
-import { userAgentHeaders } from './userAgent';
+import { request } from './client';
+
+const parseAndReject = response => response.json().then( err => Promise.reject(err) );
 
 const introspect = async function introspect({ domain, interactionHandle, stateHandle, version }) {
-
   const target = `${domain}/idp/idx/introspect`;
   const body = stateHandle ? { stateToken: stateHandle } : { interactionHandle };
-  return fetch(target, {
-    method: 'POST',
-    headers: {
-      ...userAgentHeaders(),
-      'content-type': `application/ion+json; okta-version=${version}`, // Server wants this version info
-      accept: `application/ion+json; okta-version=${version}`,
-    },
-    body: JSON.stringify(body)
-  })
-    .then( response => response.ok ? response.json() : response.json().then( err => Promise.reject(err)) );
+  const headers = {
+    'content-type': `application/ion+json; okta-version=${version}`, // Server wants this version info
+    accept: `application/ion+json; okta-version=${version}`,
+  };
+
+  return request(target, { headers, body: JSON.stringify(body) })
+    .then( response => response.ok ? response.json() : parseAndReject( response ) );
 };
 
 export default introspect;

--- a/src/v1/generateIdxAction.js
+++ b/src/v1/generateIdxAction.js
@@ -11,23 +11,23 @@
  */
 
 
-import fetch from 'cross-fetch';
+import { request } from '../client';
 import { divideActionParamsByMutability } from './actionParser';
-import { userAgentHeaders } from '../userAgent';
 import makeIdxState from './makeIdxState';
 
 const generateDirectFetch = function generateDirectFetch( { actionDefinition, defaultParamsForAction = {}, immutableParamsForAction = {}, toPersist } ) {
   const target = actionDefinition.href;
   return async function(params) {
-    return fetch(target, {
-      method: actionDefinition.method,
-      headers: {
-        ...userAgentHeaders(),
-        'content-type': 'application/json',
-        'accept': actionDefinition.accepts || 'application/ion+json',
-      },
-      body: JSON.stringify({ ...defaultParamsForAction, ...params, ...immutableParamsForAction })
-    })
+    const headers = {
+      'content-type': 'application/json',
+      'accept': actionDefinition.accepts || 'application/ion+json',
+    };
+    const body = JSON.stringify({
+      ...defaultParamsForAction,
+      ...params,
+      ...immutableParamsForAction
+    });
+    return request(target, { method: actionDefinition.method, headers, body })
       .then( response => {
         const respJson = response.json();
         if (response.ok) {

--- a/test/unit/bootstrap.test.js
+++ b/test/unit/bootstrap.test.js
@@ -1,4 +1,5 @@
 import bootstrap from '../../src/bootstrap';
+import { HttpClient } from '../../src/client';
 
 jest.mock('cross-fetch');
 import fetch from 'cross-fetch'; // import to target for mockery
@@ -6,17 +7,49 @@ import fetch from 'cross-fetch'; // import to target for mockery
 const mockInteractResponse = require('../mocks/interact-response');
 const { Response } = jest.requireActual('cross-fetch');
 
-let domain = 'http://okta.example.com';
-let stateHandle = 'FAKEY-FAKE';
-let version = '1.0.0';
-let clientId = 'CLIENT_ID';
+const mockConfig = {
+  baseUrl: 'http://okta.example.com',
+  clientId: 'CLIENT_ID',
+  redirectUri: 'redirect://',
+  codeChallenge: 'foo',
+  codeChallengeMethod: 'method',
+};
 
 describe('bootstrap', () => {
+  afterEach(() => {
+    HttpClient.interceptors.request.clear();
+  });
+
   it('fetches an interaction handle', async () => {
     fetch.mockImplementation( () => Promise.resolve( new Response(JSON.stringify( mockInteractResponse )) ) );
-    return bootstrap({ clientId, domain, scope: 'openid email' }) 
+    return bootstrap({ ...mockConfig, scope: 'openid email' })
       .then( result => {
         expect(result).toEqual('ZZZZZZZINTERACTZZZZZZZZ');
+      });
+  });
+
+  it('allows consumers of the library to pass in custom headers', async () => {
+    fetch.mockImplementation( () => Promise.resolve( new Response(JSON.stringify( mockInteractResponse )) ) );
+
+    HttpClient.interceptors.request.use( (config) => {
+      // Rewrite headers
+      config.headers['X-Test-Header'] = 'foo';
+      config.headers['X-Okta-User-Agent-Extended'] = 'my-sdk-value';
+    });
+
+    return bootstrap({ ...mockConfig })
+      .then( result => {
+        expect( fetch.mock.calls.length ).toBe(1);
+        expect( fetch.mock.calls[0][0] ).toEqual( 'http://okta.example.com/v1/interact' );
+        expect( fetch.mock.calls[0][1] ).toEqual( {
+          body: 'client_id=CLIENT_ID&scope=openid%20email&redirect_uri=redirect%3A%2F%2F&code_challenge=foo&code_challenge_method=method&state=undefined',
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+            'X-Test-Header': 'foo',
+            'X-Okta-User-Agent-Extended': 'my-sdk-value',
+          },
+          method: "POST"
+        });
       });
   });
 });

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1,0 +1,79 @@
+import { HttpClient, request } from '../../src/client';
+
+jest.mock('cross-fetch');
+import fetch from 'cross-fetch'; // import to target for mockery
+
+const mockInteractResponse = require('../mocks/interact-response');
+const { Response } = jest.requireActual('cross-fetch');
+
+describe('request', () => {
+  it('does not process interceptors when none are configured', async () => {
+    fetch.mockImplementation( () => Promise.resolve( new Response(JSON.stringify( mockInteractResponse )) ) );
+
+    return request('https://example.com', { body: 'foo=bar' })
+      .then( () => {
+        expect( fetch.mock.calls.length ).toBe(1);
+        expect( fetch.mock.calls[0][0] ).toEqual( 'https://example.com' );
+        expect( fetch.mock.calls[0][1] ).toEqual( {
+          body: 'foo=bar',
+          headers: {
+            'X-Okta-User-Agent-Extended': `okta-idx-js/${SDK_VERSION}`,
+          },
+          method: 'POST',
+        });
+      });
+  });
+
+  it('allows consumers of the library change configuration values through interceptors', async () => {
+    fetch.mockImplementation( () => Promise.resolve( new Response(JSON.stringify( mockInteractResponse )) ) );
+
+    const interceptor = (config) => {
+      // Rewrite config by reference
+      config.url = 'https://okta.com';
+      config.headers = { 'foo': 'bar' };
+      config.method = 'GET';
+      config.body = 'body value';
+    }
+
+    HttpClient.interceptors.request.use(interceptor);
+
+    return request('https://example.com', { /* use lib defaults */ })
+      .then( () => {
+        expect( fetch.mock.calls.length ).toBe(1);
+        expect( fetch.mock.calls[0][0] ).toEqual( 'https://okta.com' );
+        expect( fetch.mock.calls[0][1] ).toEqual( {
+          body: 'body value',
+          headers: {
+            'foo': 'bar',
+          },
+          method: 'GET'
+        });
+      });
+  });
+
+  it('allows consumers of the library add and remove interceptors', async () => {
+    fetch.mockImplementation( () => Promise.resolve( new Response(JSON.stringify( mockInteractResponse )) ) );
+
+    const interceptor = (config) => {
+      // Rewrite config by reference
+      config.url = 'changed';
+    }
+
+    HttpClient.interceptors.request.use(interceptor);
+
+    await request('https://example.com', { /* use lib defaults */ })
+      .then( () => {
+        expect( fetch.mock.calls.length ).toBe(1);
+        expect( fetch.mock.calls[0][0] ).toEqual( 'changed' );
+      });
+
+    // Clear all attached interceptors
+    HttpClient.interceptors.request.clear();
+
+    await request('https://example.com', { /* use lib defaults */ })
+      .then( () => {
+        expect( fetch.mock.calls.length ).toBe(2);
+        expect( fetch.mock.calls[1][0] ).toEqual( 'https://example.com' );
+      });
+  });
+});


### PR DESCRIPTION
### Description

- Allows consumers of the `okta-idx-js` package to preprocess **all** HTTP requests. This is a requirement to allow the Sign-in Widget to:
    - Extend custom headers (see: [OIE Fingerprint](https://oktawiki.atlassian.net/wiki/spaces/~yuming.cao/pages/1845726231/New+device+sign-in+notification+checking+logic+on+OIE?focusedCommentId=1912082844#OIE-Fingerprint))

#### Resolves

- [OKTA-380699](https://oktainc.atlassian.net/browse/OKTA-380699)