### PR TITLE
format errors as idx responses

### DIFF
--- a/src/v1/generateIdxAction.js
+++ b/src/v1/generateIdxAction.js
@@ -38,9 +38,16 @@ const generateDirectFetch = function generateDirectFetch( { actionDefinition, de
           // the response reaches here when Okta Verify is not installed
           // we need to return an idx object so that
           // the SIW can proceed to the next step without showing error
-          return respJson.then(err => Promise.reject(makeIdxState(err, toPersist)) );
+          return respJson.then(err => {
+            let ms = makeIdxState(err, toPersist);
+            // set to true if flow should be continued without showing any errors
+            ms.stepUp = true;
+            return Promise.reject(ms);
+          });
         }
-        return respJson.then(err => Promise.reject(err));
+        return respJson.then(err => {
+          return Promise.reject(makeIdxState(err, toPersist));
+        });
       })
       .then( idxResponse => makeIdxState(idxResponse, toPersist) );
   };

--- a/test/unit/v1/generateIdxAction.test.js
+++ b/test/unit/v1/generateIdxAction.test.js
@@ -71,7 +71,7 @@ describe('generateIdxAction', () => {
       JSON.stringify( mockIdxResponse ),
       { status: 401, headers: { 'content-type': 'application/json', 'WWW-Authenticate': 'Oktadevicejwt realm="Okta Device"' } }
     )));
-    makeIdxState.mockReturnValue('mock IdxState');
+    makeIdxState.mockReturnValue({'stepUp': true});
     const actionFunction = generateIdxAction(mockIdxResponse.remediation.value[0]);
     return actionFunction()
       .then( result => {
@@ -90,7 +90,7 @@ describe('generateIdxAction', () => {
           },
           method: 'POST'
         });
-        expect( result ).toBe('mock IdxState');
+        expect( result ).toEqual({'stepUp': true});
       });
   });
 


### PR DESCRIPTION
We had a tech debt in idx.js that it doesn't returned idx formatted errors. instead just returned the API response as it is.

This PR fixes the issue and related widget change is here https://github.com/okta/okta-signin-widget/pull/2100

https://oktainc.atlassian.net/browse/OKTA-407472

https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2216954233/Stale+Token+in+widget+after+JWE+support